### PR TITLE
エラー：carriewaveを使ってS3にアップロードできない

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ yarn-debug.log*
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+#アクセスキーを読み込ませない
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -70,3 +70,9 @@ gem 'rails-i18n'
 
 #ページネーション
 gem 'kaminari'
+
+#S3へのアップロード
+gem 'fog-aws'
+
+#環境変数設定
+gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,12 +79,33 @@ GEM
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     digest (3.1.0)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erubi (1.11.0)
+    excon (0.93.1)
     faraday (2.6.0)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.1)
     ffi (1.15.5)
+    fog-aws (3.15.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.3.0)
+      builder
+      excon (~> 0.71)
+      formatador (>= 0.2, < 2.0)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.4)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (1.1.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     hashie (5.0.0)
@@ -119,10 +140,14 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     minitest (5.16.3)
     msgpack (1.5.6)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     mysql2 (0.5.4)
     net-imap (0.2.3)
@@ -262,6 +287,8 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   carrierwave
+  dotenv-rails
+  fog-aws
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   kaminari

--- a/app/uploaders/coordinate_image_uploader.rb
+++ b/app/uploaders/coordinate_image_uploader.rb
@@ -4,8 +4,8 @@ class CoordinateImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  #storage :file
+  storage :fog
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/app/uploaders/pierce_image_uploader.rb
+++ b/app/uploaders/pierce_image_uploader.rb
@@ -4,8 +4,8 @@ class PierceImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  #storage :file
+  storage :fog
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -17,4 +17,3 @@ CarrierWave.configure do |config|
       path_style: true
     }
 end
-

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -6,7 +6,8 @@ CarrierWave.configure do |config|
     config.storage :fog
     config.fog_provider = 'fog/aws'
     config.fog_directory  = 'piercingsimulation' # 作成したバケット名を記述
-    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/piercingsimulation'
+    #config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/piercingsimulation'
+    config.asset_host = 'https://piercingsimulation.s3.ap-northeast-1.amazonaws.com'
     config.fog_public = false
     config.fog_credentials = {
       provider: 'AWS',

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -6,7 +6,7 @@ CarrierWave.configure do |config|
     config.storage :fog
     config.fog_provider = 'fog/aws'
     config.fog_directory  = 'piercingsimulation' # 作成したバケット名を記述
-    #config.fog_public = false 
+    config.fog_public = false
     config.fog_credentials = {
       provider: 'AWS',
       aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'], # 環境変数

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,17 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+    config.storage :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_directory  = 'piercingsimulation' # 作成したバケット名を記述
+    #config.fog_public = false 
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'], # 環境変数
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'], # 環境変数
+      region: 'ap-northeast-1',   # アジアパシフィック(東京)を選択した場合
+      path_style: true
+    }
+end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -6,12 +6,14 @@ CarrierWave.configure do |config|
     config.storage :fog
     config.fog_provider = 'fog/aws'
     config.fog_directory  = 'piercingsimulation' # 作成したバケット名を記述
+    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/piercingsimulation'
     config.fog_public = false
     config.fog_credentials = {
       provider: 'AWS',
-      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'], # 環境変数
-      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'], # 環境変数
+      aws_access_key_id: ENV['S3_ACCESS_KEY_ID'], # アクセスキーの環境変数
+      aws_secret_access_key: ENV['S3_SECRET_ACCESS_KEY'], # シークレットアクセスキーの環境変数
       region: 'ap-northeast-1',   # アジアパシフィック(東京)を選択した場合
       path_style: true
     }
 end
+


### PR DESCRIPTION
- 質問内容・実現したいこと
　- 現在carriewaveを使って画像アップロード機能を実装しています。アップロード先をAWSのS3にしたく実装してみましたがエラーが出てしまうのでS3にアップロードできるようにしたいです。
- 現状発生している問題・エラーメッセージ
 [![Image from Gyazo](https://i.gyazo.com/3ccabf12a677fb7f76fc0715309962ac.png)](https://gyazo.com/3ccabf12a677fb7f76fc0715309962ac)
  - エラーログ
```
app/controllers/coordinate_images_controller.rb:21:in `create'
Started POST "/coordinate_images" for ::1 at 2022-10-25 12:55:11 +0900
Processing by CoordinateImagesController#create as HTML
  Parameters: {"authenticity_token"=>"[FILTERED]", "coordinate_image"=>{"image"=>#<ActionDispatch::Http::UploadedFile:0x0000000107d85ba0 @tempfile=#<Tempfile:/var/folders/vy/twrkgjxd1f1872fbh7njp9rw0000gn/T/RackMultipart20221025-4196-ty201h.png>, @original_filename="piercing_simulation (3).png", @content_type="image/png", @headers="Content-Disposition: form-data; name=\"coordinate_image[image]\"; filename=\"piercing_simulation (3).png\"\r\nContent-Type: image/png\r\n">}, "commit"=>"Posts"}
  User Load (4.6ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 1 LIMIT 1
Completed 500 Internal Server Error in 460ms (ActiveRecord: 11.0ms | Allocations: 11466)

Excon::Error::Socket (no address for s3.ap-northeast-1.amazonaws.com (Resolv::ResolvError)):
```
- どの処理までうまく動いているのか
  - S3を導入するまではアップロード機能は正常に動いていました。 
- 該当のソースコード
- config/initializers/carrierwave.rb
```
require 'carrierwave/storage/abstract'
require 'carrierwave/storage/file'
require 'carrierwave/storage/fog'

CarrierWave.configure do |config|
    config.storage :fog
    config.fog_provider = 'fog/aws'
    config.fog_directory  = 'piercingsimulation' # 作成したバケット名を記述
    #config.fog_public = false 
    config.fog_credentials = {
      provider: 'AWS',
      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'], # 環境変数
      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'], # 環境変数
      region: 'ap-northeast-1',   # アジアパシフィック(東京)を選択した場合
      path_style: true
    }
end
```
  - coordinate_image_uploader.rb
```
(略)
 storage :fog
(略)
  def store_dir
    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
  end
(略)
```
  - バケットポリシー
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "Stmt000001",
            "Effect": "Allow",
            "Principal": {
                "AWS": "arn:aws:iam::318406515149:user/kaji_for_strage"
            },
            "Action": "s3*",
            "Resource": "arn:aws:s3:::piercingsimulation"
        }
    ]
}
```
 - coordinate_image_controller.rb
```
class CoordinateImagesController < ApplicationController
  before_action :require_login, only: %i[my_coordinate_image create destroy]

  def index
    @coordinate_images = CoordinateImage.all.order(created_at: :desc).page(params[:page])
  end

  def show
  end

  def my_coordinate_image
    @user = User.find(current_user.id)
    @my_coordinate_images = @user.coordinate_images.order(created_at: :desc).page(params[:page])
  end

  def new
    @coordinate_image = CoordinateImage.new
  end

  def create
    @coordinate_image = CoordinateImage.new(coordinate_image_params)
    if @coordinate_image.save
      flash[:success] = "投稿しました"
      redirect_to my_coordinate_images_path(current_user.id)
    else
      flash.now[:danger] = "投稿できませんでした"
      render :new
    end
  end

  def destroy
    @coordinate_image = current_user.coordinate_images.find(params[:id])
    @coordinate_image.destroy!
    flash[:success] = "削除しました"
    redirect_to my_coordinate_images_path
  end

  private

  def coordinate_image_params
    params.require(:coordinate_image).permit(:image).merge(user_id: current_user.id)
  end
end
```

- エラーから考えられる原因
  -  エラー文などで検索してみたのですが、原因の特定ができませんでした。
- 試したこと
  - アクセスキー、シークレットキーの見直し
  - config.fog_public = falseの追加

AWSの知識が浅く申し訳ないですが、アドバイスよろしくお願いいたします。 